### PR TITLE
:wrench: config: Add Toolkits menu and link to other UNICEF toolkits

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,10 +66,26 @@ privacy:
 
 menu:
   main:
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     - name: FAQ
       weight: 10
       url: faq
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+    - name: Drones
+      parent: Toolkits
+      url: https://unicef.github.io/drone-4sdgtoolkit/
+      weight: 10
 
+    - name: Open Source
+      parent: Toolkits
+      url: https://unicef.github.io/inventory/
+      weight: 20
+
+    - name: Software Development
+      parent: Toolkits
+      url: https://unicef.github.io/ooi-toolkit-software/
+      weight: 30
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     - name: pages
       weight: 20
       url: pages


### PR DESCRIPTION
This commit adds a new drop-down menu to the Data Science & A.I. site.
The _Toolkits_ drop-down includes links to @enonied4g's UNICEF Drones
for Sustainable Development Goals Toolkit. Toolkit, @jwflory's Open
Source Inventory, and @iperdomo's Software Development Toolkit.

![Screenshot of the upper-right portion of the screen. Picture is the toolkits menu with links out to the other toolkits that already exist.](https://user-images.githubusercontent.com/4721034/167942944-92b9f661-6c16-4681-b575-44b2961426d0.png "Screenshot of the upper-right portion of the screen. Picture is the toolkits menu with links out to the other toolkits that already exist.")