### PR TITLE
:new: :memo: content: Add Data Privacy & Ethics section

### DIFF
--- a/content/privacy-ethics/_index.en.md
+++ b/content/privacy-ethics/_index.en.md
@@ -1,0 +1,7 @@
+---
+title: "Data Privacy & Ethics"
+icon: "ti-eye"
+description: "Develop a more ethical, transparent, and safe AI system with these resources."
+type: "docs"
+
+---

--- a/content/privacy-ethics/milestone-roadmap.en.md
+++ b/content/privacy-ethics/milestone-roadmap.en.md
@@ -1,0 +1,70 @@
+---
+title: "AI Ethics & Transparency Roadmap - Template"
+description: How do you document your machine learning development process? This guide shares transparency best practices.
+author: Mike Nolan
+categories: privacy-ethics
+tags: ["template"]
+downloadBtn: "true"
+
+---
+
+How do you document your machine learning development process?
+This guide shares transparency best practices.
+
+This is your at a glance version of the document.
+Details and resources are below.
+
+1. Milestone 1: [**Understanding the Data Flow**](#data-flow)
+    1. Data Ecosystem Map
+    1. Information Sharing Protocol
+1. Milestone 2: [**Understanding the Algorithm**](#understand-algo)
+    1. Dataset Structure
+    1. Common Traps Mitigations
+1. Milestone 3: [**Sharing the Model**](#document-algo)
+    1. Model Card Created
+
+
+## Understanding Data Flow {#data-flow}
+
+* **Primary Goal**:
+  Create documentation that ensures you know what data you're using and how you plan on sharing it.
+
+This first milestone is about initially understanding the underlying data powering your model.
+This is generally important for understanding the plumbing and getting an idea about privacy and implications that may arise from sharing data.
+
+### Outcomes {#data-flow--outcomes}
+
+* [**Data Ecosystem Map**](https://docs.google.com/document/d/18Zg2JwUDJajVDX5VU0vMijL-c9yfumeAUYDc7rgC4iQ/edit):
+  This is to document where their data is coming from, what is using it, stakeholders, etc.
+  The benefit here is not just helping organize how data collection will work in production but also projecting partnerships which may need to be formed in the future.
+* [**Information Sharing Protocol**](https://docs.google.com/document/d/1MISHbWU7KGo4Z4AR-b222f6uXrtpQ-GJiJemGYoL--E/edit):
+  This document is all about conducting an initial assessment of the sensitivity of information you are collecting, who you want to share it with, and how.
+  It is fairly well-thought but is worth a review and potentially some edits.
+  If you are in the EU, it might just be better to do a [Data Protection Impact Assessment](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/data-protection-impact-assessments-dpias/what-is-a-dpia/).
+
+
+## Understanding the Algorithm {#understand-algo}
+
+* **Primary Goal**:
+  Create documentation to ensure your whole team understand exactly how your model will be working.
+
+A large part of this will be determining the method of managing your datasets as they evolve over the development of the program.
+
+### Outcomes {#understand-algo--outcomes}
+
+* [**Determine Dataset Structure**](https://humanitarian.atlassian.net/wiki/spaces/imtoolbox/pages/61734950/File+and+Dataset+Management):
+  As you create new data sets, update them, and remove old datasets, you should follow an easy to follow protocol for keeping track of your various data sets as they are updated and deprecated.
+* [**Common Traps When Building Models**]({{< relref "traps" >}}):
+  Review the following traps and document potential risks of your application falling into any of these traps.
+
+
+## Documenting the Algorithm {#document-algo}
+
+* **Primary Goal**:
+  Produce documentation that should be shared with the model.
+
+### Outcomes {#document-algo--outcomes}
+
+* [**Document Machine Learning Model Card**]({{< relref "model-card" >}}):
+  Before you release or begin production use of your machine learning model, you can use the linked template to comprehensively document the effects, background, and purpose of your model.
+  This will serve as a core document showing how the model makes the decision it does.

--- a/content/privacy-ethics/model-card.en.md
+++ b/content/privacy-ethics/model-card.en.md
@@ -1,0 +1,101 @@
+---
+title: "Machine Learning Model Card"
+description: Model cards help you document how your model was made. Use this overview to make your own model cards.
+author: Mike Nolan
+categories: privacy-ethics
+tags: ["design", "template"]
+downloadBtn: "true"
+
+---
+
+_The following is an editable version of the model card proposed in [arxiv.org/abs/1810.03993](https://arxiv.org/abs/1810.03993)_.
+
+
+## Model details
+
+Basic information about the model.
+
+* Person or organization developing model
+* Date of last update
+* Model version
+* Model type
+  (information about training algorithms, parameters, fairness constraints or other applied approaches, and features)
+* Paper or other resource for more information
+* Citation details
+* License
+* Maintainer contact details
+
+
+## Intended use
+
+Use cases that were envisioned during development.
+
+* Primary intended uses
+* Primary intended users
+* Out-of-scope use cases
+
+
+## Factors
+
+Factors could include demographic or phenotypic groups, environmental conditions, technical attributes, or others.
+
+* Relevant factors
+* Evaluation factors
+
+
+## Metrics
+
+Metrics should be chosen to reflect potential real-world impacts of the model.
+
+* Model performance measures
+* Decision thresholds
+* Variation approaches
+
+
+## Evaluation data
+
+Details on the dataset(s) used for the quantitative analyses in the card.
+
+* Datasets
+* Motivation
+* Preprocessing
+
+
+## Training data
+
+May not be possible to provide in practice.
+When possible, this section should mirror Evaluation Data.
+If such detail is not possible, minimal allowable information should be provided here, such as details of the distribution over various factors in the training datasets.
+
+
+## Quantitative analyses
+
+Quantitative analyses should be broken down by the chosen factors.
+
+* Unitary results
+* Intersectional results
+
+
+## Ethical considerations
+
+In this section, you should explore and document the following:
+
+* **Sensitive Data**:
+  Does the model use any sensitive data (e.g. protected classes)?
+* **Human life**:
+  Is the model intended to inform decisions about matters central to human life or flourishing – e.g., health or safety? Or could it be used in such a way?
+* **Mitigations**:
+  What risk mitigation strategies were used during model development?
+* **Risks and harms**:
+  What risks may be present in model usage?
+  Try to identify the potential recipients, likelihood, and magnitude of harms.
+  If these cannot be determined, note that they were considered but remain unknown.
+* **Use cases**:
+  Are there any known model use cases that are especially fraught?
+
+
+## Caveats and recommendations
+
+This section should list additional concerns that were not covered in the previous sections.
+
+To be written.

--- a/content/privacy-ethics/policy-guidance-children.en.md
+++ b/content/privacy-ethics/policy-guidance-children.en.md
@@ -1,0 +1,38 @@
+---
+title: Policy guidance on AI for children (via unicef.org)
+description: Recommendations for building AI policies and systems that uphold child rights. Part of UNICEF AI for children project.
+author: Mike Nolan
+categories: privacy-ethics
+tags: ["artificial-intelligence","children", "policy"]
+downloadBtn: "true"
+
+---
+
+As part of our [AI for children project](https://www.unicef.org/globalinsight/featured-projects/ai-children), UNICEF has developed this policy guidance to promote children's rights in government and private sector AI policies and practices, and to raise awareness of how AI systems can uphold or undermine these rights.
+The policy guidance explores AI systems, and considers the ways in which they impact children.
+
+
+## Read in full: [**unicef.org/globalinsight/reports/policy-guidance-ai-children**](https://www.unicef.org/globalinsight/reports/policy-guidance-ai-children) {#url}
+
+Drawing on the Convention on the Rights of the Child, the guidance offers nine requirements for child-centered AI:
+
+1. Support children’s development and well-being
+1. Ensure inclusion of and for children
+1. Prioritize fairness and non-discrimination for children
+1. Protect children’s data and privacy
+1. Ensure safety for children
+1. Provide transparency, explainability, and accountability for children
+1. Empower governments and businesses with knowledge of AI and children’s rights
+1. Prepare children for present and future developments in AI
+1. Create an enabling environment
+
+To support implementation of the guidance, a list of online resources and a set of practical implementation tools are provided, including:
+
+1. [Roadmap for policymakers](https://www.unicef.org/globalinsight/media/1166/file/UNICEF-Global-Insight-tools-to-operationalize-AI-policy-guidance-2020.pdf)
+1. [AI for children development canvas](https://www.unicef.org/globalinsight/media/1166/file/UNICEF-Global-Insight-tools-to-operationalize-AI-policy-guidance-2020.pdf)
+1. [AI guide for parents](https://www.unicef.org/globalinsight/media/2336/file)
+1. [AI guide for teens](https://www.unicef.org/globalinsight/media/2341/file)
+
+To see how the guidance has been applied in practice, read about the eight [case studies](https://www.unicef.org/globalinsight/policy-guidance-ai-children-pilot-testing-and-case-studies).
+
+[**_Read more on unicef.org_**](https://www.unicef.org/globalinsight/reports/policy-guidance-ai-children).

--- a/content/privacy-ethics/traps.en.md
+++ b/content/privacy-ethics/traps.en.md
@@ -1,0 +1,73 @@
+---
+title: Common traps to avoid when building AI systems
+description: Assessing common AI/ML mistakes that lead to unintended side effects.
+author: Mike Nolan
+categories: privacy-ethics
+tags: ["design"]
+downloadBtn: "true"
+
+---
+
+_Assessing common mistakes that lead to unintended side effects_.
+Information summarized from [_Fairness and Abstraction in Sociotechnical Systems_](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3265913), a paper published at the 2019 ACM Conference on Fairness, Accountability, and Transparency.
+
+
+## Framing Trap
+
+_Failure to model the entire system over which a social criterion, such as fairness, will be enforced_.
+
+For this trap, we will want to look at our outcome variables.
+Are these variables a proxy of the actual outcome you wish to achieve?
+What evidence of existing negative bias currently exists with regards to these variables?
+
+
+## Portability Trap
+
+_Failure to understand how repurposing algorithmic solutions designed for one social context may be misleading, inaccurate, or otherwise do harm when applied to a different context_.
+
+Here, you will want to be fully understanding of the context in which this model is being built for and the context in which you will be using it.
+There should be clear documentation distributed across the entire team focusing on this.
+What stakeholders do you expect to have an impact on where this technology will be used.
+Are they informed?
+
+
+## Formalism Trap
+
+_Failure to account for the full meaning of social concepts such as fairness, which can be procedural, contextual, and contestable, and cannot be resolved through mathematical formalisms_.
+
+How does your chosen outcome continue to implement and solve existing procedural "catches" in order to ensure the decision making process is fair?
+What method of recourse are available for those who are unfairly judged?
+
+
+## Ripple Effect Trap
+
+_Failure to understand how the insertion of technology into an existing social system changes the behaviors and embedded values of the pre-existing system_.
+
+How do you think the introduction of this recommendation system will affect your users?
+What changes in behavior do you intend to change?
+Can you think of any possible changes in behavior that you don't intend as a result of your software?
+
+
+## Solutionism Trap
+
+_Failure to recognize the possibility that the best solution to a problem may not involve technology_.
+
+Will this technology elevate social values which can be quantified?
+Will it devalue those which cannot?
+What values might take a back seat if this technology is implemented?
+
+
+## Attributions
+
+Thanks to the publishers of the [original paper](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3265913):
+
+* **Andrew D. Selbst**
+  (UCLA School of Law)
+* **Danah Boyd**
+  (Data & Society Research Institute; Microsoft Research)
+* **Sorelle Friedler**
+  (Haverford College)
+* **Suresh Venkatasubramanian**
+  (University of Utah)
+* **Janet Vertesi**
+  (Princeton University)


### PR DESCRIPTION
This commit imports the Data Ethics & Transparency section from the
UNICEF Open Source Inventory and imports it as a new category (Data
Privacy & Ethics) in the Data Science & A.I. Toolkit. The content was
converted from AsciiDoc to Markdown to match the syntax used in this
repository.

Additionally, the theme submodule was updated to include recent changes
and improvements made to the UNICEF Inventory theme, like the author
by-lines (see unicef/inventory-hugo-theme#15).

Related to unicef/inventory#128 but does not close it. Closes unicef/unicef/ooi-toolkit-ds#1.

![Screenshot of the website homepage, with the Data Privacy & Ethics category added.](https://user-images.githubusercontent.com/4721034/174861665-114b1803-c818-4303-9d03-82b36ff4cc26.png "Screenshot of the website homepage, with the Data Privacy & Ethics category added.")

![Screenshot of the index page for the Data Privacy & Ethics category, showing the pages contained in the category.](https://user-images.githubusercontent.com/4721034/174861696-81320852-61f5-43da-a69e-09742c6640f0.png "Screenshot of the index page for the Data Privacy & Ethics category, showing the pages contained in the category.")

![Screenshot of the AI Ethics & Transparency Roadmap template article in the Data Privacy & Ethics category.](https://user-images.githubusercontent.com/4721034/174861730-497d7430-4ccf-45ee-9a12-ca5821287735.png "Screenshot of the AI Ethics & Transparency Roadmap template article in the Data Privacy & Ethics category.")