### PR TITLE
:memo: content: Move URL from header into main text

### DIFF
--- a/content/privacy-ethics/policy-guidance-children.en.md
+++ b/content/privacy-ethics/policy-guidance-children.en.md
@@ -12,7 +12,9 @@ As part of our [AI for children project](https://www.unicef.org/globalinsight/fe
 The policy guidance explores AI systems, and considers the ways in which they impact children.
 
 
-## Read in full: [**unicef.org/globalinsight/reports/policy-guidance-ai-children**](https://www.unicef.org/globalinsight/reports/policy-guidance-ai-children) {#url}
+## Read in full {#url}
+
+[**unicef.org/globalinsight/reports/policy-guidance-ai-children**](https://www.unicef.org/globalinsight/reports/policy-guidance-ai-children)
 
 Drawing on the Convention on the Rights of the Child, the guidance offers nine requirements for child-centered AI:
 


### PR DESCRIPTION
This commit moves the URL from the full report linked in the "Policy
Guidance on AI for Children" article from a header and into the main
text body.